### PR TITLE
Sample: reboot vm example

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 argparse
 pyvmomi
+requests
 suds>=0.4,<0.7

--- a/samples/reboot_vm.py
+++ b/samples/reboot_vm.py
@@ -1,21 +1,24 @@
-# Written by Michael Rice
-# Github: https://github.com/michaelrice
-# Website: https://michaelrice.github.io/
-# Blog: http://www.errr-online.com/
-# This code has been released under the terms of the MIT licenses
-# http://opensource.org/licenses/MIT
+"""Written by Michael Rice
+Github: https://github.com/michaelrice
+Website: https://michaelrice.github.io/
+Blog: http://www.errr-online.com/
+This code has been released under the terms of the MIT licenses
+http://opensource.org/licenses/MIT
+
+Example script to reboot a VirtualMachine
+
+"""
 __author__ = 'errr'
 
 from tools import cli
-from tools import taskops
+from tools import tasks
 from pyVim import connect
 
 import atexit
 
 
 def setup_args():
-    """
-    Adds additional args to allow the vm name or uuid to
+    """Adds additional ARGS to allow the vm name or uuid to
     be set.
     """
     parser = cli.build_arg_parser()
@@ -23,41 +26,46 @@ def setup_args():
     parser.add_argument('-j', '--uuid',
                         help='UUID of the VirtualMachine you want to reboot.')
     parser.add_argument('-n', '--name',
-                        help='DNS Name of the VirtualMachine you want to reboot.')
+                        help='DNS Name of the VirtualMachine you want to '
+                             'reboot.')
     parser.add_argument('-i', '--ip',
-                        help='IP Address of the VirtualMachine you want to reboot')
+                        help='IP Address of the VirtualMachine you want to '
+                             'reboot')
 
     my_args = parser.parse_args()
 
     return cli.prompt_for_password(my_args)
 
 
-args = setup_args()
-si = None
+ARGS = setup_args()
+SI = None
 try:
-    si = connect.SmartConnect(host=args.host,
-                              user=args.user,
-                              pwd=args.password,
-                              port=int(args.port))
-    atexit.register(connect.Disconnect, si)
-except IOError, e:
+    SI = connect.SmartConnect(host=ARGS.host,
+                              user=ARGS.user,
+                              pwd=ARGS.password,
+                              port=ARGS.port)
+    atexit.register(connect.Disconnect, SI)
+except IOError, ex:
     pass
 
-if not si:
+if not SI:
     raise SystemExit("Unable to connect to host with supplied info.")
-vm = None
-if args.uuid:
-    vm = si.content.searchIndex.FindByUuid(None, args.uuid, True)
-elif args.name:
-    vm = si.content.searchIndex.FindByDnsName(None, args.name, True)
-elif args.ip:
-    vm = si.content.searchIndex.FindByIp(None, args.ip, True)
+VM = None
+if ARGS.uuid:
+    VM = SI.content.searchIndex.FindByUuid(None, ARGS.uuid,
+                                           True,
+                                           True)
+elif ARGS.name:
+    VM = SI.content.searchIndex.FindByDnsName(None, ARGS.name,
+                                              True)
+elif ARGS.ip:
+    VM = SI.content.searchIndex.FindByIp(None, ARGS.ip, True)
 
-if vm is None:
+if VM is None:
     raise SystemExit("Unable to locate VirtualMachine.")
 
-print "Found: {0}".format(vm.name)
-print "The current powerState is: {0}".format(vm.runtime.powerState)
-task = vm.ResetVM_Task()
-taskops.wait_for_tasks([task], si)
+print "Found: {0}".format(VM.name)
+print "The current powerState is: {0}".format(VM.runtime.powerState)
+TASK = VM.ResetVM_Task()
+tasks.wait_for_tasks(SI, [TASK])
 print "its done."

--- a/samples/tools/tasks.py
+++ b/samples/tools/tasks.py
@@ -1,24 +1,25 @@
-# Written by Michael Rice
-# Github: https://github.com/michaelrice
-# Website: https://michaelrice.github.io/
-# Blog: http://www.errr-online.com/
-# This code has been released under the terms of the MIT licenses
-# http://opensource.org/licenses/MIT 
+"""Written by Michael Rice
+
+Github: https://github.com/michaelrice
+Website: https://michaelrice.github.io/
+Blog: http://www.errr-online.com/
+This code has been released under the terms of the MIT licenses
+http://opensource.org/licenses/MIT
+
+Helper module for task operations.
+"""
 __author__ = 'errr'
 
-from pyVmomi import vim, vmodl
+from pyVmomi import vim
+from pyVmomi import vmodl
 
 
-def wait_for_tasks(tasks, si):
-    """
-   Given the service instance si and tasks, it returns after all the
+def wait_for_tasks(service_instance, tasks):
+    """Given the service instance si and tasks, it returns after all the
    tasks are complete
    """
-
-    property_collector = si.content.propertyCollector
-
+    property_collector = service_instance.content.propertyCollector
     task_list = [str(task) for task in tasks]
-
     # Create filter
     obj_specs = [vmodl.query.PropertyCollector.ObjectSpec(obj=task)
                  for task in tasks]
@@ -29,17 +30,15 @@ def wait_for_tasks(tasks, si):
     filter_spec.objectSet = obj_specs
     filter_spec.propSet = [property_spec]
     pcfilter = property_collector.CreateFilter(filter_spec, True)
-
     try:
         version, state = None, None
-
         # Loop looking for updates till the state moves to a completed state.
         while len(task_list):
             update = property_collector.WaitForUpdates(version)
-            for filterSet in update.filterSet:
-                for objSet in filterSet.objectSet:
-                    task = objSet.obj
-                    for change in objSet.changeSet:
+            for filter_set in update.filterSet:
+                for obj_set in filter_set.objectSet:
+                    task = obj_set.obj
+                    for change in obj_set.changeSet:
                         if change.name == 'info':
                             state = change.val.state
                         elif change.name == 'info.state':


### PR DESCRIPTION
I added an example to reboot a vm (forcibly) using ResetVM_Task. You can enter a UUID, an IP, or a DNS Name to search for the vm.

I also put the WaitForTasks from the poweron example into a taskops module and renamed the function to follow pep8 conventions.

I also noticed one of the new examples `create_random_marvel_vms.py` used requests so I added that to the requirements file.
