### PR TITLE
getallvms.py should include UUID

### DIFF
--- a/samples/getallvms.py
+++ b/samples/getallvms.py
@@ -45,6 +45,7 @@ def print_vm_info(vm, depth=1):
 
     summary = vm.summary
     print "Name       : ", summary.config.name
+    print "UUID       : ", summary.config.instanceUuid
     print "Path       : ", summary.config.vmPathName
     print "Guest      : ", summary.config.guestFullName
     annotation = summary.config.annotation


### PR DESCRIPTION
I've included the UUID for the instance here because the UUID
is a more durable and unique identifier than name.c

closes https://github.com/vmware/pyvmomi-community-samples/issues/66
closes #66
