### PR TITLE
getallvms should use UUID

### DIFF
--- a/samples/getallvms.py
+++ b/samples/getallvms.py
@@ -45,6 +45,7 @@ def print_vm_info(vm, depth=1):
 
     summary = vm.summary
     print "Name       : ", summary.config.name
+    print "UUID       : ", summary.config.instanceUuid
     print "Path       : ", summary.config.vmPathName
     print "Guest      : ", summary.config.guestFullName
     annotation = summary.config.annotation


### PR DESCRIPTION
UUID is a better identifier than Name. It's more durable and
it is unique to a VM instance accross time and space.

closes https://github.com/vmware/pyvmomi-community-samples/pull/67
closes #67
