### PR TITLE
fix broken `getallvms.py`

### DIFF
--- a/samples/getallvms.py
+++ b/samples/getallvms.py
@@ -38,7 +38,7 @@ def print_vm_info(virtual_machine, depth=1):
     if hasattr(virtual_machine, 'childEntity'):
         if depth > maxdepth:
             return
-        vmList = vm.childEntity
+        vmList = virtual_machine.childEntity
         for c in vmList:
             print_vm_info(c, depth + 1)
         return


### PR DESCRIPTION
A refactor seems to have broken the sample, `vm` was renamed to `virtual_machine` and since there are no tests nobody caught this.
