### PR TITLE
adding overlay wrapper for interactive experiments

### DIFF
--- a/samples/tests/interactive_wrapper_tests.py
+++ b/samples/tests/interactive_wrapper_tests.py
@@ -1,0 +1,112 @@
+from unittest import TestCase
+from mock import Mock
+
+from samples.tools.interactive_wrapper import (
+    VM,
+    ESX,
+    get_all_vms_in_folder
+)
+
+
+class VMTests(TestCase):
+
+    def setUp(self):
+        self.raw_vm = Mock()
+        self.wrapped_vm = VM(self.raw_vm)
+
+    def test_should_passthrough_unwrapped_attributes(self):
+        self.assertEqual(self.wrapped_vm.anything, self.raw_vm.anything)
+
+    def test_should_return_interface_when_one_matches(self):
+        foo_mock = lambda: None
+        foo_mock.name = "foo"
+        bar_mock = lambda: None
+        bar_mock.name = "bar"
+        self.raw_vm.network = [foo_mock, bar_mock]
+
+        bar = lambda n: n.name == "bar"
+        actual = self.wrapped_vm.get_first_network_interface_matching(bar)
+
+        self.assertEqual(actual, bar_mock)
+
+    def test_should_return_first_interface_when_several_match(self):
+        aha_mock = lambda: None
+        aha_mock.name = "aha"
+        foo_mock_1 = lambda: None
+        foo_mock_1.name = "foo"
+        bar_mock = lambda: None
+        bar_mock.name = "bar"
+        foo_mock_2 = lambda: None
+        foo_mock_2.name = "foo"
+        self.raw_vm.network = [aha_mock, foo_mock_1, bar_mock, foo_mock_2]
+
+        foo = lambda n: n.name == "foo"
+        actual = self.wrapped_vm.get_first_network_interface_matching(foo)
+
+        self.assertEqual(actual, foo_mock_1)
+
+
+class ESXTests(TestCase):
+
+    def setUp(self):
+        self.raw_esx = Mock()
+        self.raw_esx.name = "esx-name"
+        self.wrapped_esx = ESX(self.raw_esx)
+
+    def test_should_passthrough_unwrapped_attributes(self):
+        self.assertEqual(self.wrapped_esx.anything, self.raw_esx.anything)
+
+    def test_should_equal_to_esx_with_same_name(self):
+        other_raw_esx = Mock()
+        other_raw_esx.name = "esx-name"
+        other_esx = ESX(other_raw_esx)
+
+        self.assertTrue(self.wrapped_esx == other_esx)
+
+    def test_should_not_equal_to_esx_with_other_name(self):
+        other_raw_esx = Mock()
+        other_raw_esx.name = "other-esx-name"
+        other_esx = ESX(other_raw_esx)
+
+        self.assertFalse(self.wrapped_esx == other_esx)
+
+    def test_should_raise_when_number_of_cores_not_in_resources(self):
+        resources = []
+        self.raw_esx.licensableResource.resource = resources
+
+        self.assertRaises(RuntimeError, self.wrapped_esx.get_number_of_cores)
+
+    def test_should_return_number_of_cores_when_in_resources(self):
+        resource_1 = Mock()
+        resource_1.key = "weLoveCamelCase"
+        resource_2 = Mock()
+        resource_2.key = "numCpuCores"
+        resource_2.value = 42
+        resource_3 = Mock()
+        resource_3.key = "someOtherKey"
+
+        resources = [resource_1, resource_2, resource_3]
+        self.raw_esx.licensableResource.resource = resources
+
+        self.assertEquals(self.wrapped_esx.get_number_of_cores(), 42)
+
+
+class getAllVMInFolderTests(TestCase):
+
+    def test_should_resolve_deep_nesting(self):
+        vm_1 = lambda: None
+        vm_1.name = "vm-1"
+        vm_2 = lambda: None
+        vm_2.name = "vm-2"
+        level_2_nesting = [vm_2]
+        child_folder = Mock()
+        child_folder.childEntity = level_2_nesting
+        level_1_nesting = [vm_1, child_folder]
+        root_folder = Mock()
+        root_folder.childEntity = level_1_nesting
+
+        actual_vms = [vm for vm in get_all_vms_in_folder(root_folder)]
+
+        self.assertEqual(len(actual_vms), 2)
+        self.assertEqual(actual_vms[0].raw_vm, vm_1)
+        self.assertEqual(actual_vms[1].raw_vm, vm_2)

--- a/samples/tools/interactive_wrapper.py
+++ b/samples/tools/interactive_wrapper.py
@@ -1,0 +1,126 @@
+import atexit
+from getpass import getpass
+
+from pyVim import connect
+
+"""
+This module overlays the pyVmomi library to make its use in a
+python shell or short program more enjoyable.
+Starting point is instantiating a vCenter Host (VVC) in order
+to get all VMs.
+"""
+
+
+class VVC(object):
+    """
+    A vCenter host.
+    """
+
+    def __init__(self, hostname):
+        """
+        Creates a VVC instance.
+
+        - `hostname` (str) is the name of the vCenter host.
+        """
+        self.hostname = hostname
+
+    def connect(self, username, password=None):
+        """
+        Connects to the vCenter host encapsulated by this VVC instance.
+
+        - `username` (str) is the username to use for authentication.
+        - `password` (str) is the password to use for authentication.
+          If the password is not specified, a getpass prompt will be used.
+        """
+        if not password:
+            password = getpass("Password for {0}: ".format(self.hostname))
+        self.service_instance = connect.SmartConnect(host=self.hostname,
+                                                     user=username,
+                                                     pwd=password,
+                                                     port=443)
+        atexit.register(connect.Disconnect, self.service_instance)
+
+    def get_first_level_of_vm_folders(self):
+        content = self.service_instance.RetrieveContent()
+        children = content.rootFolder.childEntity
+        for child in children:
+            if hasattr(child, "vmFolder"):
+                yield child.vmFolder
+
+    def get_all_vms(self):
+        """
+        Returns a generator over all VMs known to this vCenter host.
+        """
+        for folder in self.get_first_level_of_vm_folders():
+            for vm in get_all_vms_in_folder(folder):
+                yield vm
+
+
+class ESX(object):
+    """
+    An ESX instance.
+    """
+
+    def __init__(self, raw_esx):
+        self.raw_esx = raw_esx
+        self.name = raw_esx.name
+
+    def __eq__(self, other):
+        return self.name == other.name
+
+    def __hash__(self):
+        return int("".join((str(ord(c)) for c in self.name)))
+
+    def __getattr__(self, attribute):
+        return getattr(self.raw_esx, attribute)
+
+    def get_number_of_cores(self):
+        """
+        Returns the number of CPU cores (type long) on this ESX.
+        """
+        resources_on_esx = self.raw_esx.licensableResource.resource
+        for resource in resources_on_esx:
+            if resource.key == "numCpuCores":
+                return resource.value
+        message = "{0} has no resource numCpuCores.\n Available resources: {1}"
+        raise RuntimeError(message.format(self.name, resources_on_esx))
+
+
+class VM(object):
+    """
+    A virtual machine.
+    """
+
+    def __init__(self, raw_vm):
+        self.raw_vm = raw_vm
+        self.name = raw_vm.name
+
+    def __getattr__(self, attribute):
+        return getattr(self.raw_vm, attribute)
+
+    def get_first_network_interface_matching(self, predicate):
+        """
+        Returns the first network interface of this VM that matches the given
+        predicate.
+
+        - `predicate` (callable) is a function that takes a network and returns
+          True (return this network) or False (skip this network).
+        """
+        for network in self.raw_vm.network:
+            if predicate(network):
+                return network
+        return None
+
+    def get_esx_host(self):
+        return ESX(self.raw_vm.runtime.host)
+
+
+def get_all_vms_in_folder(folder):
+    vm_or_folders = folder.childEntity
+    for vm_or_folder in vm_or_folders:
+        if hasattr(vm_or_folder, "childEntity"):
+            # it's still a folder, look deeper
+            for vm in get_all_vms_in_folder(vm_or_folder):
+                yield vm  # it's now a VM
+        else:
+            yield VM(vm_or_folder)  # it's a VM


### PR DESCRIPTION
Hi @hartsock,
This is my old pull request, rebased and with the pep8 issues fixed.
I also moved the module into the `tools` package, which is much more fitting as you mentioned.
I squashed everything into one commit.

This makes simple experiments in an interactive python shell much
easier. After authenticating to a vCenter host interactively, it
is possible to directly iterate over all VMs with very little code.

Wrappers are provided for convenience, though they passthrough any
undefined fields or methods to the underlying VIM object.
