### PR TITLE
unverified http contexts [PEP0466]

### DIFF
--- a/samples/add_disk_to_vm.py
+++ b/samples/add_disk_to_vm.py
@@ -131,7 +131,8 @@ def main():
         host=args.host,
         user=args.user,
         pwd=args.password,
-        port=args.port)
+        port=args.port,
+        unverified=True)
     # disconnect this thing
     atexit.register(Disconnect, si)
 

--- a/samples/add_vm_extra_config_tags.py
+++ b/samples/add_vm_extra_config_tags.py
@@ -46,7 +46,8 @@ try:
     si = connect.SmartConnect(host=args.host,
                               user=args.user,
                               pwd=args.password,
-                              port=int(args.port))
+                              port=int(args.port),
+                              unverified=True)
     atexit.register(connect.Disconnect, si)
 except IOError:
     pass

--- a/samples/create_random_marvel_vms.py
+++ b/samples/create_random_marvel_vms.py
@@ -157,7 +157,8 @@ def main():
     service_instance = connect.SmartConnect(host=args.host,
                                             user=args.user,
                                             pwd=args.password,
-                                            port=int(args.port))
+                                            port=int(args.port),
+                                            unverified=True)
     if not service_instance:
         print("Could not connect to the specified host using specified "
               "username and password")

--- a/samples/esxi_perf_sample.py
+++ b/samples/esxi_perf_sample.py
@@ -70,7 +70,8 @@ def main():
         service_instance = connect.SmartConnect(host=args.host,
                                                 user=args.user,
                                                 pwd=args.password,
-                                                port=int(args.port))
+                                                port=int(args.port),
+                                                unverified=True)
         if not service_instance:
             print("Could not connect to the specified host using specified "
                   "username and password")

--- a/samples/find_by_uuid.py
+++ b/samples/find_by_uuid.py
@@ -63,7 +63,7 @@ args = get_args()
 
 # form a connection...
 si = connect.SmartConnect(host=args.host, user=args.user, pwd=args.password,
-                          port=args.port)
+                          port=args.port, unverified=True)
 
 # doing this means you don't need to remember to disconnect your script/objects
 atexit.register(connect.Disconnect, si)

--- a/samples/getallvms.py
+++ b/samples/getallvms.py
@@ -21,6 +21,7 @@ Python program for listing the vms on an ESX / vCenter host
 import atexit
 
 from pyVim import connect
+from pyVmomi import vim
 from pyVmomi import vmodl
 
 import tools.cli as cli
@@ -41,6 +42,9 @@ def print_vm_info(virtual_machine, depth=1):
         vmList = virtual_machine.childEntity
         for c in vmList:
             print_vm_info(c, depth + 1)
+        return
+
+    if not isinstance(virtual_machine, vim.VirtualMachine):
         return
 
     summary = virtual_machine.summary
@@ -80,7 +84,8 @@ def main():
         service_instance = connect.SmartConnect(host=args.host,
                                                 user=args.user,
                                                 pwd=args.password,
-                                                port=int(args.port))
+                                                port=int(args.port),
+                                                unverified=True)
 
         atexit.register(connect.Disconnect, service_instance)
 

--- a/samples/getorphanedvms.py
+++ b/samples/getorphanedvms.py
@@ -211,7 +211,8 @@ def main():
             si = SmartConnect(host=args.host,
                               user=args.user,
                               pwd=args.password,
-                              port=int(args.port))
+                              port=int(args.port),
+                              unverified=True)
         except IOError, e:
             pass
 

--- a/samples/hello_world_vcenter.py
+++ b/samples/hello_world_vcenter.py
@@ -76,7 +76,8 @@ def main():
         service_instance = connect.SmartConnect(host=args.host,
                                                 user=args.user,
                                                 pwd=args.password,
-                                                port=int(args.port))
+                                                port=int(args.port),
+                                                unverified=True)
 
         atexit.register(connect.Disconnect, service_instance)
 

--- a/samples/hello_world_vcenter_with_yaml_recorder.py
+++ b/samples/hello_world_vcenter_with_yaml_recorder.py
@@ -82,7 +82,8 @@ def main():
             service_instance = connect.SmartConnect(host=args.host,
                                                     user=args.user,
                                                     pwd=args.password,
-                                                    port=int(args.port))
+                                                    port=int(args.port),
+                                                    unverified=True)
             # the recording will show up in the working directory
 
         atexit.register(connect.Disconnect, service_instance)

--- a/samples/list_datastore_cluster.py
+++ b/samples/list_datastore_cluster.py
@@ -54,7 +54,8 @@ def main():
         service_instance = connect.SmartConnect(host=args.host,
                                                 user=args.user,
                                                 pwd=args.password,
-                                                port=int(args.port))
+                                                port=int(args.port),
+                                                unverified=True)
         if not service_instance:
             print("Could not connect to the specified host using "
                   "specified username and password")

--- a/samples/list_datastore_info.py
+++ b/samples/list_datastore_info.py
@@ -82,7 +82,8 @@ def main():
         service_instance = connect.SmartConnect(host=args.host,
                                                 user=args.user,
                                                 pwd=args.password,
-                                                port=int(args.port))
+                                                port=int(args.port),
+                                                unverified=True)
         if not service_instance:
             print("Could not connect to the specified host using specified "
                   "username and password")

--- a/samples/list_host_alarms.py
+++ b/samples/list_host_alarms.py
@@ -31,7 +31,8 @@ cli.prompt_for_password(MY_ARGS)
 SI = SmartConnect(host=MY_ARGS.host,
                   user=MY_ARGS.user,
                   pwd=MY_ARGS.password,
-                  port=MY_ARGS.port)
+                  port=MY_ARGS.port,
+                  unverified=True)
 
 atexit.register(Disconnect, SI)
 INDEX = SI.content.searchIndex

--- a/samples/make_dc_and_cluster.py
+++ b/samples/make_dc_and_cluster.py
@@ -32,7 +32,8 @@ cli.prompt_for_password(MY_ARGS)
 SI = SmartConnect(host=MY_ARGS.host,
                   user=MY_ARGS.user,
                   pwd=MY_ARGS.password,
-                  port=MY_ARGS.port)
+                  port=MY_ARGS.port,
+                  unverified=True)
 
 atexit.register(Disconnect, SI)
 dc = datacenter.create_datacenter(dcname=MY_ARGS.dcname, service_instance=SI)

--- a/samples/pyvmomi-to-suds.py
+++ b/samples/pyvmomi-to-suds.py
@@ -85,7 +85,8 @@ print "pyVmomi login... "
 si = connect.SmartConnect(host=args.host,
                           user=args.user,
                           pwd=password,
-                          port=int(args.port))
+                          port=int(args.port),
+                          unverified=True)
 
 print "current session id: %s" % si.content.sessionManager.currentSession.key
 pyvmomi_cookie = si._stub.cookie

--- a/samples/reboot_vm.py
+++ b/samples/reboot_vm.py
@@ -44,7 +44,8 @@ try:
     SI = connect.SmartConnect(host=ARGS.host,
                               user=ARGS.user,
                               pwd=ARGS.password,
-                              port=ARGS.port)
+                              port=ARGS.port,
+                              unverified=True)
     atexit.register(connect.Disconnect, SI)
 except IOError, ex:
     pass

--- a/samples/renamer.py
+++ b/samples/renamer.py
@@ -76,7 +76,7 @@ args = get_args()
 
 # form a connection...
 si = connect.SmartConnect(host=args.host, user=args.user, pwd=args.password,
-                          port=args.port)
+                          port=args.port, unverified=True)
 
 # doing this means you don't need to remember to disconnect your script/objects
 atexit.register(connect.Disconnect, si)

--- a/samples/sessions_list.py
+++ b/samples/sessions_list.py
@@ -69,7 +69,8 @@ else:
 si = connect.SmartConnect(host=args.host,
                           user=args.user,
                           pwd=password,
-                          port=int(args.port))
+                          port=int(args.port),
+                          unverified=True)
 
 print "logged in to %s" % args.host
 session_id = si.content.sessionManager.currentSession.key

--- a/samples/set_note.py
+++ b/samples/set_note.py
@@ -44,7 +44,8 @@ try:
     si = connect.SmartConnect(host=args.host,
                               user=args.user,
                               pwd=args.password,
-                              port=int(args.port))
+                              port=int(args.port),
+                              unverified=True)
     atexit.register(connect.Disconnect, si)
 except IOError, e:
     pass

--- a/samples/soft_reboot.py
+++ b/samples/soft_reboot.py
@@ -33,7 +33,8 @@ try:
     si = connect.SmartConnect(host=args.host,
                               user=args.user,
                               pwd=args.password,
-                              port=int(args.port))
+                              port=int(args.port),
+                              unverified=True)
     atexit.register(connect.Disconnect, si)
 except IOError, e:
     pass

--- a/samples/suds-to-pyvmomi.py
+++ b/samples/suds-to-pyvmomi.py
@@ -114,7 +114,8 @@ print "suds session to pyvmomi "
 si = connect.SmartConnect(host=args.host,
                           user=args.user,
                           pwd=password,
-                          port=int(args.port))
+                          port=int(args.port),
+                          unverified=True)
 
 # logout the current session since we won't be using it.
 si.content.sessionManager.Logout()

--- a/samples/upload_file_to_datastore.py
+++ b/samples/upload_file_to_datastore.py
@@ -44,7 +44,8 @@ def main():
             service_instance = connect.SmartConnect(host=args.host,
                                                     user=args.user,
                                                     pwd=args.password,
-                                                    port=int(args.port))
+                                                    port=int(args.port),
+                                                    unverified=True)
         except IOError as e:
             pass
         if not service_instance:

--- a/samples/upload_file_to_vm.py
+++ b/samples/upload_file_to_vm.py
@@ -66,7 +66,8 @@ def main():
         service_instance = connect.SmartConnect(host=args.host,
                                                 user=args.user,
                                                 pwd=args.password,
-                                                port=int(args.port))
+                                                port=int(args.port),
+                                                unverified=True)
 
         atexit.register(connect.Disconnect, service_instance)
         content = service_instance.RetrieveContent()

--- a/samples/vSphereAutoRestartManager.py
+++ b/samples/vSphereAutoRestartManager.py
@@ -23,7 +23,7 @@ __author__ = 'humayunjamal'
 def get_connection(ipadd, user, password):
     try:
         connection = SmartConnect(
-            host=ipadd, port=443, user=user, pwd=password)
+            host=ipadd, port=443, user=user, pwd=password, unverified=True)
     except Exception as e:
         print e
         raise SystemExit

--- a/samples/vcenter_details.py
+++ b/samples/vcenter_details.py
@@ -57,7 +57,8 @@ def main():
         service_instance = connect.SmartConnect(host=args.host,
                                                 user=args.user,
                                                 pwd=args.password,
-                                                port=int(args.port))
+                                                port=int(args.port),
+                                                unverified=True)
 
         if not service_instance:
             print("Could not connect to the specified host using specified "

--- a/samples/virtual_machine_device_info.py
+++ b/samples/virtual_machine_device_info.py
@@ -205,7 +205,7 @@ args = get_args()
 
 # form a connection...
 si = connect.SmartConnect(host=args.host, user=args.user, pwd=args.password,
-                          port=args.port)
+                          port=args.port, unverified=True)
 
 # Note: from daemons use a shutdown hook to do this, not the atexit
 atexit.register(connect.Disconnect, si)

--- a/samples/virtual_machine_power_cycle_and_question.py
+++ b/samples/virtual_machine_power_cycle_and_question.py
@@ -116,7 +116,7 @@ def answer_vm_question(virtual_machine):
 # form a connection...
 args = get_args()
 si = connect.SmartConnect(host=args.host, user=args.user, pwd=args.password,
-                          port=args.port)
+                          port=args.port, unverified=True)
 
 # doing this means you don't need to remember to disconnect your script/objects
 atexit.register(connect.Disconnect, si)

--- a/samples/vminfo_quick.py
+++ b/samples/vminfo_quick.py
@@ -46,7 +46,8 @@ try:
     service_instance = connect.SmartConnect(host=args.host,
                                             user=args.user,
                                             pwd=args.password,
-                                            port=int(args.port))
+                                            port=int(args.port),
+                                            unverified=True)
     atexit.register(connect.Disconnect, service_instance)
     atexit.register(endit)
 except IOError as e:

--- a/samples/waitforupdates.py
+++ b/samples/waitforupdates.py
@@ -260,7 +260,7 @@ def main():
             urllib3.disable_warnings()
 
         si = SmartConnect(host=args.host, user=args.user, pwd=password,
-                          port=int(args.port))
+                          port=int(args.port), unverified=True)
 
         if not si:
             print >>sys.stderr, "Could not connect to the specified host ' \


### PR DESCRIPTION
Add the `unverfied=True` parameter to all connect calls allowing the 
samples changed to connect to vCenter or ESXi hosts that do not 
have signed SSL certificates. This is related to changes made for 
PEP0466.

See: https://github.com/vmware/pyvmomi/pull/252

fixes: https://github.com/vmware/pyvmomi/issues/212, https://github.com/vmware/pyvmomi/issues/235, and https://github.com/vmware/pyvmomi/issues/179
