### PR TITLE
Update the open() function in upload_file_to_vm.py

### DIFF
--- a/samples/upload_file_to_vm.py
+++ b/samples/upload_file_to_vm.py
@@ -82,7 +82,7 @@ def main():
 
         creds = vim.vm.guest.NamePasswordAuthentication(
             username=args.vm_user, password=args.vm_pwd)
-        with open(args.upload_file, 'r') as myfile:
+        with open(args.upload_file, 'rb') as myfile:
             args = myfile.read()
 
         try:


### PR DESCRIPTION
Chnaged the open file mode when using open() function.
When trying to upload executable files or unicode text files, you got problems of encoding while pasting the "args".
'rb' reading the file in binary mode which will have the best result while pasting the "args" to the guest.