### PR TITLE
Getallvms fixed

### DIFF
--- a/samples/getallvms.py
+++ b/samples/getallvms.py
@@ -76,9 +76,11 @@ def main():
 
         content = service_instance.RetrieveContent()
 
-        viewType = [vim.VirtualMachine]
+        container = content.rootFolder  # starting point to look into
+        viewType = [vim.VirtualMachine]  # object types to look for
+        recursive = True  # whether we should look into it recursively
         containerView = content.viewManager.CreateContainerView(
-            content.rootFolder, viewType, True)
+            container, viewType, recursive)
 
         children = containerView.view
         for child in children:

--- a/samples/getallvms.py
+++ b/samples/getallvms.py
@@ -77,7 +77,8 @@ def main():
         content = service_instance.RetrieveContent()
 
         viewType = [vim.VirtualMachine]
-        containerView = content.viewManager.CreateContainerView(content.rootFolder, viewType, True)
+        containerView = content.viewManager.CreateContainerView(
+            content.rootFolder, viewType, True)
 
         children = containerView.view
         for child in children:


### PR DESCRIPTION
As the samples should show how to do something, I think the getallvms sample should use the viewManager to get all the Virtual Machines.

This sample is a good example of how not to get all the vms, as there is a chance you don't get them all using it. There are (at least) 2 bugs in it, regarding the depth and the children objects (for virtualapps for example).

If really wanted, I can commit a fixed version of getallvms as cross_vm_tree.py (or something), although I don't see the use.