### PR TITLE
Make deploy_ovf.py work for vCenter as well

### DIFF
--- a/samples/deploy_ovf.py
+++ b/samples/deploy_ovf.py
@@ -189,7 +189,7 @@ def main():
                                            objs["resource pool"],
                                            objs["datastore"],
                                            spec_params)
-    lease = objs["resource pool"].ImportVApp(import_spec.importSpec)
+    lease = objs["resource pool"].ImportVApp(import_spec.importSpec, objs["datacenter"].vmFolder)
     while(True):
         if (lease.state == vim.HttpNfcLease.State.ready):
             # Assuming single VMDK.

--- a/samples/deploy_ovf.py
+++ b/samples/deploy_ovf.py
@@ -189,7 +189,8 @@ def main():
                                            objs["resource pool"],
                                            objs["datastore"],
                                            spec_params)
-    lease = objs["resource pool"].ImportVApp(import_spec.importSpec, objs["datacenter"].vmFolder)
+    lease = objs["resource pool"].ImportVApp(import_spec.importSpec,
+        objs["datacenter"].vmFolder)
     while(True):
         if (lease.state == vim.HttpNfcLease.State.ready):
             # Assuming single VMDK.

--- a/samples/deploy_ovf.py
+++ b/samples/deploy_ovf.py
@@ -190,7 +190,7 @@ def main():
                                            objs["datastore"],
                                            spec_params)
     lease = objs["resource pool"].ImportVApp(import_spec.importSpec,
-        objs["datacenter"].vmFolder)
+                                             objs["datacenter"].vmFolder)
     while(True):
         if (lease.state == vim.HttpNfcLease.State.ready):
             # Assuming single VMDK.


### PR DESCRIPTION
Fix for vmware/pyvmomi#281. Now the _host_ can be vCenter as well as an ESXi host.