### PR TITLE
Getallvms allow selfsigned certs

### DIFF
--- a/samples/getallvms.py
+++ b/samples/getallvms.py
@@ -26,6 +26,8 @@ from pyVmomi import vim
 
 import tools.cli as cli
 
+import ssl
+
 
 def print_vm_info(virtual_machine):
     """
@@ -66,11 +68,18 @@ def main():
 
     args = cli.get_args()
 
+    ssl_options = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH,
+                                             capath=None, cadata=None)
+    if args.insecure:
+        ssl_options.check_hostname = False
+        ssl_options.verify_mode = ssl.CERT_NONE
+
     try:
         service_instance = connect.SmartConnect(host=args.host,
                                                 user=args.user,
                                                 pwd=args.password,
-                                                port=int(args.port))
+                                                port=int(args.port),
+                                                sslContext=ssl_options)
 
         atexit.register(connect.Disconnect, service_instance)
 

--- a/samples/tools/cli.py
+++ b/samples/tools/cli.py
@@ -57,6 +57,13 @@ def build_arg_parser():
                         required=False,
                         action='store',
                         help='Password to use when connecting to host')
+
+    parser.add_argument('-i', '--insecure',
+                        required=False,
+                        type=bool,
+                        default=False,
+                        action='store',
+                        help='Ignore server certificate')
     return parser
 
 

--- a/samples/tools/cli.py
+++ b/samples/tools/cli.py
@@ -60,9 +60,8 @@ def build_arg_parser():
 
     parser.add_argument('-i', '--insecure',
                         required=False,
-                        type=bool,
                         default=False,
-                        action='store',
+                        action='store_true',
                         help='Ignore server certificate')
     return parser
 


### PR DESCRIPTION
Hello,

trying to learn using this library the first problem i got was that we are using self signed certificates on our vcenters. So I implemented a new flag that if set ignores certificate errors, calling it --insecure / -i.

I'm a newbie in python but this works as expected from my tests, so please consider for inclusions.

Thanks,
Frederik
