### PR TITLE
bugfix and error handling

### DIFF
--- a/samples/export_vm.py
+++ b/samples/export_vm.py
@@ -226,6 +226,14 @@ def main():
                 print_http_nfc_lease_info(http_nfc_lease.info)
 
                 for deviceUrl in http_nfc_lease.info.deviceUrl:
+                    if not deviceUrl.targetId:
+                        print "No targetId found for url: {}."\
+                            .format(deviceUrl.url)
+                        print "Device is not eligible for export. This " \
+                              "could be a mounted iso or img of some sort"
+                        print "Skipping..."
+                        continue
+
                     temp_target_disk = os.path.join(target_directory,
                                                     deviceUrl.targetId)
                     print 'Downloading {} to {}'.format(deviceUrl.url,
@@ -268,7 +276,8 @@ def main():
         else:
             vm_descriptor = vm_descriptor_result.ovfDescriptor
             target_ovf_descriptor_path = os.path.join(target_directory,
-                                                      args.name + '.ovf')
+                                                      vm_descriptor_name +
+                                                      '.ovf')
             print 'Writing OVF Descriptor {}'.format(
                 target_ovf_descriptor_path)
             with open(target_ovf_descriptor_path, 'wb') as handle:


### PR DESCRIPTION
Add error handling if a vm to be exported contains mounted isos or images which would otherwise cause a nonetype error.

Bugfix for when users chose not to set an ovf name as an argument