### PR TITLE
destroy_vm.py tweaks

### DIFF
--- a/samples/destroy_vm.py
+++ b/samples/destroy_vm.py
@@ -24,7 +24,9 @@ from pyVmomi import vim
 from tools import cli
 from tools import tasks
 
+
 def setup_args():
+
     """Adds additional ARGS to allow the vm name or uuid to
     be set.
     """
@@ -47,7 +49,10 @@ def setup_args():
 
     return cli.prompt_for_password(my_args)
 
+
 def get_obj(content, vimtype, name):
+
+    """Create contrainer view and search for object in it"""
     obj = None
     container = content.viewManager.CreateContainerView(
         content.rootFolder, vimtype, True)
@@ -91,7 +96,11 @@ elif ARGS.ip:
     VM = SI.content.searchIndex.FindByIp(None, ARGS.ip, True)
 
 if VM is None:
-    raise SystemExit("Unable to locate VirtualMachine. Arguments given: vm - {0} , uuid - {1} , name - {2} , ip - {3}".format(ARGS.vm, ARGS.uuid, ARGS.name, ARGS.ip))
+    raise SystemExit(
+        "Unable to locate VirtualMachine. Arguments given: "\
+        "vm - {0} , uuid - {1} , name - {2} , ip - {3}"
+        .format(ARGS.vm, ARGS.uuid, ARGS.name, ARGS.ip)
+        )
 
 print("Found: {0}".format(VM.name))
 print("The current powerState is: {0}".format(VM.runtime.powerState))

--- a/samples/destroy_vm.py
+++ b/samples/destroy_vm.py
@@ -17,16 +17,12 @@ from __future__ import print_function
 
 import atexit
 
-import ssl
-import requests
 from pyVim import connect
 
 from pyVmomi import vim
 
 from tools import cli
 from tools import tasks
-
-requests.packages.urllib3.disable_warnings()
 
 def setup_args():
     """Adds additional ARGS to allow the vm name or uuid to
@@ -64,24 +60,22 @@ def get_obj(content, vimtype, name):
             obj = c
             break
 
+    container.Destroy()
     return obj
 
 ARGS = setup_args()
 SI = None
 try:
-    context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
-
-    SI = connect.SmartConnect(host=ARGS.host,
-                              user=ARGS.user,
-                              pwd=ARGS.password,
-                              port=ARGS.port,
-                              sslContext=context)
+    SI = connect.SmartConnectNoSSL(host=ARGS.host,
+                                   user=ARGS.user,
+                                   pwd=ARGS.password,
+                                   port=ARGS.port)
     atexit.register(connect.Disconnect, SI)
-except IOError, ex:
+except (IOError, vim.fault.InvalidLogin):
     pass
 
 if not SI:
-    raise SystemExit("Unable to connect to host with supplied info.")
+    raise SystemExit("Unable to connect to host with supplied credentials.")
 
 VM = None
 if ARGS.vm:
@@ -97,7 +91,7 @@ elif ARGS.ip:
     VM = SI.content.searchIndex.FindByIp(None, ARGS.ip, True)
 
 if VM is None:
-    raise SystemExit("Unable to locate VirtualMachine. Arguments given: vm - %s , uuid - %s , name - %s , ip - %s" % (ARGS.vm, ARGS.uuid, ARGS.name, ARGS.ip))
+    raise SystemExit("Unable to locate VirtualMachine. Arguments given: vm - {0} , uuid - {1} , name - {2} , ip - {3}".format(ARGS.vm, ARGS.uuid, ARGS.name, ARGS.ip))
 
 print("Found: {0}".format(VM.name))
 print("The current powerState is: {0}".format(VM.runtime.powerState))

--- a/samples/destroy_vm.py
+++ b/samples/destroy_vm.py
@@ -97,7 +97,7 @@ elif ARGS.ip:
 
 if VM is None:
     raise SystemExit(
-        "Unable to locate VirtualMachine. Arguments given: "\
+        "Unable to locate VirtualMachine. Arguments given: "
         "vm - {0} , uuid - {1} , name - {2} , ip - {3}"
         .format(ARGS.vm, ARGS.uuid, ARGS.name, ARGS.ip)
         )

--- a/samples/destroy_vm.py
+++ b/samples/destroy_vm.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 
 import atexit
 
+import ssl
 import requests
 from pyVim import connect
 
@@ -24,7 +25,6 @@ from tools import cli
 from tools import tasks
 
 requests.packages.urllib3.disable_warnings()
-
 
 def setup_args():
     """Adds additional ARGS to allow the vm name or uuid to
@@ -50,10 +50,13 @@ def setup_args():
 ARGS = setup_args()
 SI = None
 try:
+    context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+
     SI = connect.SmartConnect(host=ARGS.host,
                               user=ARGS.user,
                               pwd=ARGS.password,
-                              port=ARGS.port)
+                              port=ARGS.port,
+                              sslContext=context)
     atexit.register(connect.Disconnect, SI)
 except IOError, ex:
     pass


### PR DESCRIPTION
* Allow specifying VM by inventory name
* Really ignore certificate errors
* Provide information on arguments passed if no VM is found. Useful if wrapping in a loop.