### PR TITLE
Example snapshot revert tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ docs/_build/
 
 # ignore flight recorder YAML file
 */hello_world_vcenter.yaml
+
+# vim backup
+*.swp

--- a/samples/.restore_config
+++ b/samples/.restore_config
@@ -1,0 +1,6 @@
+host: 10.16.240.12
+user: Administrator@vsphere.local
+vm_name: dcs1
+snap_name: initial
+debug: true
+insecure: true

--- a/samples/.restore_config
+++ b/samples/.restore_config
@@ -1,6 +1,7 @@
 host: 10.16.240.12
 user: Administrator@vsphere.local
-vm_names: dcs1
+vm_names: [vm1 vm2]
 snap_name: initial
 debug: true
 insecure: true
+save_first: true

--- a/samples/.restore_config
+++ b/samples/.restore_config
@@ -1,6 +1,6 @@
 host: 10.16.240.12
 user: Administrator@vsphere.local
-vm_name: dcs1
+vm_names: dcs1
 snap_name: initial
 debug: true
 insecure: true

--- a/samples/restore_from_snap.py
+++ b/samples/restore_from_snap.py
@@ -24,6 +24,7 @@ DEFAULT_CONFIG_FILENAME = ".restore_config"
 BASE_DESCRIPTION = 'Tool to automate reverting VMs to known snapshots' +\
                     ' via vSphere.'
 
+
 def report(message):
     """
     Timestamped message output.

--- a/samples/restore_from_snap.py
+++ b/samples/restore_from_snap.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+#
+# checks for snapshots on a list of specific VMs, and restores them to those states
+#
+
+import atexit
+import configargparse
+import getpass
+import re
+import ssl
+import sys
+
+from pyVim import connect
+from pyVim.task import WaitForTask
+from pyVmomi import vmodl, vim
+
+DEFAULT_CONFIG_FILENAME = ".restore_config"
+
+
+class EsxTalker(object):
+    """
+    Class that handles talking to ESX and holds the various utility methods
+    """
+
+    def __init__(self, args):
+        self.args = args  # as there may be more than just the esx creds
+        # magic to disable SSL cert checking
+        s = None
+        if args.insecure:
+            s = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+            s.verify_mode = ssl.CERT_NONE
+        try:
+            self.service_instance = connect.SmartConnect(host=args.host,
+                                                         user=args.user,
+                                                         pwd=args.password,
+                                                         port=int(args.port),
+                                                         sslContext=s)
+            atexit.register(connect.Disconnect, self.service_instance)
+            self.session_id = self.service_instance.content.sessionManager.currentSession.key
+            assert self.session_id is not None, "Connection to ESX failed"
+
+        except vmodl.MethodFault as error:
+            print "Caught vmodl fault : " + error.msg
+            sys.exit(1)
+        self.content = self.service_instance.RetrieveContent()
+
+    def get_obj(self, vimtype, name):
+        """
+         Get the vsphere object associated with a given text name
+        """
+        obj = None
+        container = self.content.viewManager.CreateContainerView(
+            self.content.rootFolder, vimtype, True)
+        for c in container.view:
+            if c.name == name:
+                return c
+        return None
+
+    def get_vm_by_name(self, name):
+        return self.get_obj([vim.VirtualMachine], name)
+
+    def get_snapshots(self, rootlist):
+        results = []
+        for s in rootlist:
+            results.append(s)
+            results += self.get_snapshots(s.childSnapshotList)
+        return results
+
+    def find_matching_snapshot(self, snapshots, regex):
+        if snapshots is None:
+            return None
+        if len(snapshots) < 1:
+            return None
+        results = []
+        return [s for s in snapshots if re.search(regex, s.name)]
+
+
+
+def get_args():
+    """
+    Get command line args from the user.
+    Uses configargparse so can use combination of command line, config file and env vars
+    """
+    parser = configargparse.ArgParser(
+        config_file_parser_class=configargparse.YAMLConfigFileParser,
+        default_config_files=[DEFAULT_CONFIG_FILENAME],
+        description='Tool to manipulate VM snapshots on ESX cluster')
+    parser.add_argument('-c', '--my-config',
+                        required=False, 
+                        is_config_file=True,
+                        help='config file path')
+    parser.add_argument('-H', '--host',
+                        required=True,
+                        action='store',
+                        help='vSphere service to connect to')
+    parser.add_argument('-P', '--port',
+                        type=int,
+                        default=443,
+                        action='store',
+                        help='Port to connect on')
+    parser.add_argument('-u', '--user',
+                        required=True,
+                        action='store',
+                        help='User name to use when connecting to host')
+    parser.add_argument('-p', '--password',
+                        required=False,
+                        action='store',
+                        env_var="ESX_PASSWORD",
+                        help='Password to use when connecting to host')
+    parser.add_argument('-v', '--vm_name',
+                        required=True,
+                        action='store',
+                        env_var="VM_NAME",
+                        help='VM name')
+    parser.add_argument('-s', '--snap_name',
+                        required=True,
+                        env_var="SNAP_NAME",
+                        action='store',
+                        help="String to use when searching snapshot names")
+    parser.add_argument('-d', '--debug',
+                        required=False,
+                        action='store_true',
+                        env_var="DEBUG",
+                        help='Debug mode - do not do the revert')
+    parser.add_argument('-i', '--insecure',
+                        required=False,
+                        action='store_true',
+                        help='Insecure mode - do not validate the SSL certificate')
+    args = parser.parse_args()
+    if not args.password:
+        args.password = getpass.getpass(
+            prompt='Enter password for host %s and user %s: ' %
+                   (args.host, args.user))
+    return args
+
+
+def main():
+    """
+    """
+
+    args = get_args()
+    et = EsxTalker(args)
+
+    print "Get VM by name =", args.vm_name
+    dcsvm = et.get_vm_by_name(args.vm_name)
+ 
+    print "Get snapshots from %s ..." % args.vm_name
+    snaps = et.get_snapshots(dcsvm.snapshot.rootSnapshotList)
+
+    print "Finding initial snapshot ..."
+    initial_snap = et.find_matching_snapshot(snaps, args.snap_name)
+
+    print "Snap found matching name ..."
+    for s in initial_snap:
+        print "initial snap name = ", s.name
+
+    assert len(initial_snap) == 1, "More than one snap identified!"
+ 
+    thesnap2use = initial_snap[0]
+    if args.debug:
+        print "DEBUG : This task will cause the VM to revert", thesnap2use.snapshot.RevertToSnapshot_Task
+    else:
+        print "NOT_DEBUG : WaitForTask(thesname2use.snapshot.RevertToSnapshot_Task())"
+    
+    
+
+
+# Start program
+if __name__ == "__main__":
+    main()
+

--- a/samples/restore_from_snap.py
+++ b/samples/restore_from_snap.py
@@ -24,6 +24,11 @@ class EsxTalker(object):
     """
 
     def __init__(self, args):
+        """
+        Initialise the EsxTalker.
+        :param args - the params passed to the program, which must include
+                      the username, password and host for the vSphere
+        """
         self.args = args  # as there may be more than just the esx creds
         # magic to disable SSL cert checking
         s = None
@@ -46,7 +51,10 @@ class EsxTalker(object):
 
     def get_obj(self, vimtype, name):
         """
-         Get the vsphere object associated with a given text name
+        Get the vsphere object associated with a given text name
+        :param vimtype - type of object searched for.
+        :param name - name of item searched for.
+        :return matching object or None
         """
         obj = None
         container = self.content.viewManager.CreateContainerView(
@@ -57,9 +65,20 @@ class EsxTalker(object):
         return None
 
     def get_vm_by_name(self, name):
+        """
+        Get the VM object for the VM with the given name
+        :param name - exact name of target VM
+        :return matching VM or None
+        """
         return self.get_obj([vim.VirtualMachine], name)
 
     def get_snapshots(self, rootlist):
+        """
+        Starting from the root list, return
+        a list of snapshots.
+        :param rootlist - the VM snapshot rootlist
+        :return list of snapshots
+        """
         results = []
         for s in rootlist:
             results.append(s)
@@ -67,11 +86,18 @@ class EsxTalker(object):
         return results
 
     def find_matching_snapshot(self, snapshots, regex):
+        """
+        Return the list of existing snapshots filtered using
+        a regex - which can be a simple substring expected to
+        be found in the name field.
+        :param snapshots - list of snapshots
+        :param regex - string with an expression to re.search on.
+        :return filtered list
+        """
         if snapshots is None:
             return None
         if len(snapshots) < 1:
             return None
-        results = []
         return [s for s in snapshots if re.search(regex, s.name)]
 
 

--- a/samples/restore_from_snap.py
+++ b/samples/restore_from_snap.py
@@ -107,10 +107,11 @@ def get_args():
                         action='store',
                         env_var="ESX_PASSWORD",
                         help='Password to use when connecting to host')
-    parser.add_argument('-v', '--vm_name',
+    parser.add_argument('-v', '--vm_names',
                         required=True,
-                        action='store',
+                        action='append',
                         env_var="VM_NAME",
+                        default=[],
                         help='VM name')
     parser.add_argument('-s', '--snap_name',
                         required=True,
@@ -142,23 +143,26 @@ def main():
     args = get_args()
     et = EsxTalker(args)
 
-    print "Get VM by name =", args.vm_name
-    dcsvm = et.get_vm_by_name(args.vm_name)
-    print "Get snapshots from %s ..." % args.vm_name
-    snaps = et.get_snapshots(dcsvm.snapshot.rootSnapshotList)
-    print "Finding initial snapshot ..."
-    initial_snap = et.find_matching_snapshot(snaps, args.snap_name)
-    print "Snap found matching name ..."
-    for s in initial_snap:
-        print "initial snap name = ", s.name
-    assert len(initial_snap) == 1, "More than one snap identified - confused!"
-    thesnap2use = initial_snap[0]
-    if args.debug:
-        print "DEBUG : This task will cause the VM to revert",
-        thesnap2use.snapshot.RevertToSnapshot_Task
-    else:
-        print "NOT_DEBUG:",
-        "WaitForTask(thesname2use.snapshot.RevertToSnapshot_Task())"
+    print "Get VM by names =", args.vm_names
+    for name in args.vm_names:
+        vm = et.get_vm_by_name(name)
+        print "Get snapshots from %s ..." % vm
+        snaps = et.get_snapshots(vm.snapshot.rootSnapshotList)
+        print "Finding initial snapshot ..."
+        initial_snap = et.find_matching_snapshot(snaps, args.snap_name)
+        print "Snap found matching name ..."
+        for s in initial_snap:
+            print "initial snap name = ", s.name
+            assert len(initial_snap) == 1,\
+                "More than one snap identified - confused!\n" +\
+                "Please use more unique string."
+        thesnap2use = initial_snap[0]
+        if args.debug:
+            print "DEBUG : This task will cause the VM to revert",
+            thesnap2use.snapshot.RevertToSnapshot_Task
+        else:
+            print "NOT_DEBUG:",
+            "WaitForTask(thesname2use.snapshot.RevertToSnapshot_Task())"
 
 
 if __name__ == "__main__":

--- a/samples/restore_from_snap.py
+++ b/samples/restore_from_snap.py
@@ -210,7 +210,7 @@ def get_args():
     parser.add_argument('-S', '--save_first',
                         required=False,
                         action='store_true',
-                        help='Before doing a revert, snapshot the current state.')
+                        help='Before doing a revert, snapshot current state.')
     parser.add_argument('-i', '--insecure',
                         required=False,
                         action='store_true',

--- a/samples/restore_from_snap.py
+++ b/samples/restore_from_snap.py
@@ -129,10 +129,10 @@ class EsxTalker(object):
                                           quiesce))
             """
         else:
-            WaitForTaskvm(vm.CreateSnapshot(snap_name,
-                                            description,
-                                            dumpMem,
-                                            quiesce))
+            WaitForTask(vm.CreateSnapshot(snapname,
+                                          description,
+                                          dumpMem,
+                                          quiesce))
 
     def revert_to_snap(self, vmname, snapnameregex):
         """
@@ -156,7 +156,7 @@ class EsxTalker(object):
             print "DEBUG : This task will cause the VM to revert",
             thesnap2use.snapshot.RevertToSnapshot_Task
         else:
-            WaitForTask(thesname2use.snapshot.RevertToSnapshot_Task())
+            WaitForTask(thesnap2use.snapshot.RevertToSnapshot_Task())
 
 
 def get_args():
@@ -207,6 +207,10 @@ def get_args():
                         action='store_true',
                         env_var="DEBUG",
                         help='Debug mode - do not do the revert')
+    parser.add_argument('-S', '--save_first',
+                        required=False,
+                        action='store_true',
+                        help='Before doing a revert, snapshot the current state.')
     parser.add_argument('-i', '--insecure',
                         required=False,
                         action='store_true',
@@ -229,11 +233,12 @@ def main():
 
     print "Get VM by names =", args.vm_names
     for vmname in args.vm_names:
-        # prior to winding back, create a snapshot of now - just in case
-        print "snapshotting prior to revert"
-        new_snap_name = "%s_PREREVERT_%s" % (vmname, str(time.time()))
-        description = "Snapshot prior to revert operation"
-        et.create_snapshot(vmname, new_snap_name, description)
+        if args.save_first:
+            # prior to winding back, create a snapshot of now - just in case
+            print "snapshotting prior to revert"
+            new_snap_name = "%s_PREREVERT_%s" % (vmname, str(time.time()))
+            description = "Snapshot prior to revert operation"
+            et.create_snapshot(vmname, new_snap_name, description)
         # now do the revert
         et.revert_to_snap(vmname, args.snap_name)
 


### PR DESCRIPTION
This tool illustrates how to create and revert snapshots with the key logic wrapped up in a gateway object. 
It makes use of configargparse rather than argparse in other examples as this permits use of a config file and/or environment variables. 