### PR TITLE
Make deploy_ova.py python3 compliant

### DIFF
--- a/samples/deploy_ova.py
+++ b/samples/deploy_ova.py
@@ -354,13 +354,13 @@ class WebHandle(object):
     def _headers_to_dict(self, r):
         result = {}
         if hasattr(r, 'getheaders'):
-           for n, v in r.getheaders():
-               result[n.lower()] = v.strip()
+            for n, v in r.getheaders():
+                result[n.lower()] = v.strip()
         else:
-           for line in r.info().headers:
-               if line.find(':') != -1:
-                   n, v = line.split(': ', 1)
-                   result[n.lower()] = v.strip()
+            for line in r.info().headers:
+                if line.find(':') != -1:
+                    n, v = line.split(': ', 1)
+                    result[n.lower()] = v.strip()
         return result
 
     def tell(self):


### PR DESCRIPTION
* Properly handle binary for file handles.
* http response behaves differently for header information, so handle
  both situations.
* tarfile doesn't have 'size' property on python3, but also isn't needed
  to supply the content-size.

Tested with both python2 and python3, both file and http ova files.