### PR TITLE
Fix compatibility on "_create_unverified_context" of module ssl

### DIFF
--- a/samples/list_vm_storage_policy.py
+++ b/samples/list_vm_storage_policy.py
@@ -29,12 +29,16 @@ def GetPbmConnection(vpxdStub):
     httpContext["cookies"] = cookie
     VmomiSupport.GetRequestContext()["vcSessionCookie"] = sessionCookie
     hostname = vpxdStub.host.split(":")[0]
+
+    context = None
+    if hasattr(ssl, "_create_unverified_context"):
+        context = ssl._create_unverified_context()
     pbmStub = pyVmomi.SoapStubAdapter(
         host=hostname,
         version="pbm.version.version1",
         path="/pbm/sdk",
         poolSize=0,
-        sslContext=ssl._create_unverified_context())
+        sslContext=context)
     pbmSi = pbm.ServiceInstance("ServiceInstance", pbmStub)
     pbmContent = pbmSi.RetrieveContent()
 
@@ -78,11 +82,14 @@ def main():
             prompt='Enter password for host %s and '
                    'user %s: ' % (args.host, args.user))
 
+    context = None
+    if hasattr(ssl, "_create_unverified_context"):
+        context = ssl._create_unverified_context()
     si = SmartConnect(host=args.host,
                       user=args.user,
                       pwd=password,
                       port=int(args.port),
-                      sslContext=ssl._create_unverified_context())
+                      sslContext=context)
 
     atexit.register(Disconnect, si)
 

--- a/samples/service_manager_esxtop_in_vc.py
+++ b/samples/service_manager_esxtop_in_vc.py
@@ -46,11 +46,14 @@ def main():
             prompt='Enter password for host %s and '
                    'user %s: ' % (args.host, args.user))
 
+    context = None
+    if hasattr(ssl, "_create_unverified_context"):
+        context = ssl._create_unverified_context()
     si = SmartConnect(host=args.host,
                       user=args.user,
                       pwd=password,
                       port=int(args.port),
-                      sslContext=ssl._create_unverified_context())
+                      sslContext=context)
 
     atexit.register(Disconnect, si)
 

--- a/samples/service_manager_vscsistats_in_vc.py
+++ b/samples/service_manager_vscsistats_in_vc.py
@@ -46,11 +46,14 @@ def main():
             prompt='Enter password for host %s and '
                    'user %s: ' % (args.host, args.user))
 
+    context = None
+    if hasattr(ssl, "_create_unverified_context"):
+        context = ssl._create_unverified_context()
     si = SmartConnect(host=args.host,
                       user=args.user,
                       pwd=password,
                       port=int(args.port),
-                      sslContext=ssl._create_unverified_context())
+                      sslContext=context)
 
     atexit.register(Disconnect, si)
 

--- a/samples/update_vm_storage_policy.py
+++ b/samples/update_vm_storage_policy.py
@@ -30,12 +30,16 @@ def GetPbmConnection(vpxdStub):
     httpContext["cookies"] = cookie
     VmomiSupport.GetRequestContext()["vcSessionCookie"] = sessionCookie
     hostname = vpxdStub.host.split(":")[0]
+
+    context = None
+    if hasattr(ssl, "_create_unverified_context"):
+        context = ssl._create_unverified_context()
     pbmStub = pyVmomi.SoapStubAdapter(
         host=hostname,
         version="pbm.version.version1",
         path="/pbm/sdk",
         poolSize=0,
-        sslContext=ssl._create_unverified_context())
+        sslContext=context)
     pbmSi = pbm.ServiceInstance("ServiceInstance", pbmStub)
     pbmContent = pbmSi.RetrieveContent()
 
@@ -118,11 +122,14 @@ def main():
         password = getpass.getpass(prompt='Enter password for host %s and '
                                    'user %s: ' % (args.host, args.user))
 
+    context = None
+    if hasattr(ssl, "_create_unverified_context"):
+        context = ssl._create_unverified_context()
     si = SmartConnect(host=args.host,
                       user=args.user,
                       pwd=password,
                       port=int(args.port),
-                      sslContext=ssl._create_unverified_context())
+                      sslContext=context)
 
     atexit.register(Disconnect, si)
 


### PR DESCRIPTION
The method "_create_unverified_context" only works with python >= 2.7.9.
There is no need to use it when python version lower.