### PR TITLE
upload_file_to_datastore: Don't define duplicate -S flag

### DIFF
--- a/samples/upload_file_to_datastore.py
+++ b/samples/upload_file_to_datastore.py
@@ -25,10 +25,6 @@ def get_args():
                         required=True,
                         action='store',
                         help='Path on datastore to place file')
-    parser.add_argument('-S', '--disable_ssl_verification',
-                        required=False,
-                        action='store_true',
-                        help='Disable ssl host certificate verification')
     args = parser.parse_args()
 
     return cli.prompt_for_password(args)


### PR DESCRIPTION
Change 36e55798 introduced a '--disable_ssl_verification' flag in the
common argument definitions in tools.cli. By specifying it in the
upload_file_to_datastore script as well, the script will raise an
exception about "conflicting option string(s)" at startup. We don't need
it defined twice, so we can safely remove it from the
upload_file_to_datastore script.