### PR TITLE
handle "VM not found" scenario in upload_file_to_vm script

### DIFF
--- a/samples/upload_file_to_vm.py
+++ b/samples/upload_file_to_vm.py
@@ -17,6 +17,7 @@ from tools import tasks
 from pyVim import connect
 from pyVmomi import vim, vmodl
 import re
+import sys
 
 
 def get_args():
@@ -73,6 +74,9 @@ def main():
         content = service_instance.RetrieveContent()
 
         vm = content.searchIndex.FindByUuid(None, args.vm_uuid, True)
+        if vm is None:
+            print("VM not found,verify the UUID of the VM")
+            sys.exit()
         tools_status = vm.guest.toolsStatus
         if (tools_status == 'toolsNotInstalled' or
                 tools_status == 'toolsNotRunning'):


### PR DESCRIPTION
This is a fix for issue#442. When the user inputs the wrong uuid,
SearchByUuid function returns None as expected and the script fails
when trying to get vm info on None. Fixing this by retuning an error
when no VM is found for the corresponding Uuid , and exiting .