### PR TITLE
Now returns a list of ipv4 addresses #2

### DIFF
--- a/samples/getvmsbycluster.py
+++ b/samples/getvmsbycluster.py
@@ -53,14 +53,14 @@ def getNICs(summary, guest):
                 nics[nic.macAddress] = {}  # Use mac as uniq ID for nic
                 nics[nic.macAddress]['netlabel'] = nic.network
                 ipconf = nic.ipConfig.ipAddress
-		i=0
-		nics[nic.macAddress]['ipv4'] = {}
+                i=0
+                nics[nic.macAddress]['ipv4'] = {}
                 for ip in ipconf:
                     if ":" not in ip.ipAddress:  # Only grab ipv4 addresses
-			nics[nic.macAddress]['ipv4'][i] = ip.ipAddress
+                        nics[nic.macAddress]['ipv4'][i] = ip.ipAddress
                         nics[nic.macAddress]['prefix'] = ip.prefixLength
                         nics[nic.macAddress]['connected'] = nic.connected
-		    i=i+1
+                i=i+1
     return nics
 
 

--- a/samples/getvmsbycluster.py
+++ b/samples/getvmsbycluster.py
@@ -53,14 +53,14 @@ def getNICs(summary, guest):
                 nics[nic.macAddress] = {}  # Use mac as uniq ID for nic
                 nics[nic.macAddress]['netlabel'] = nic.network
                 ipconf = nic.ipConfig.ipAddress
-                i=0
+                i = 0
                 nics[nic.macAddress]['ipv4'] = {}
                 for ip in ipconf:
                     if ":" not in ip.ipAddress:  # Only grab ipv4 addresses
                         nics[nic.macAddress]['ipv4'][i] = ip.ipAddress
                         nics[nic.macAddress]['prefix'] = ip.prefixLength
                         nics[nic.macAddress]['connected'] = nic.connected
-                i=i+1
+                i = i+1
     return nics
 
 

--- a/samples/getvmsbycluster.py
+++ b/samples/getvmsbycluster.py
@@ -53,11 +53,14 @@ def getNICs(summary, guest):
                 nics[nic.macAddress] = {}  # Use mac as uniq ID for nic
                 nics[nic.macAddress]['netlabel'] = nic.network
                 ipconf = nic.ipConfig.ipAddress
+		i=0
+		nics[nic.macAddress]['ipv4'] = {}
                 for ip in ipconf:
                     if ":" not in ip.ipAddress:  # Only grab ipv4 addresses
-                        nics[nic.macAddress]['ip'] = ip.ipAddress
+			nics[nic.macAddress]['ipv4'][i] = ip.ipAddress
                         nics[nic.macAddress]['prefix'] = ip.prefixLength
                         nics[nic.macAddress]['connected'] = nic.connected
+		    i=i+1
     return nics
 
 


### PR DESCRIPTION
Useful if a single NIC has multiple ipv4 addresses assigned.
Example:
`"ipv4": { "0": "172.26.117.166", "1": "172.26.117.180", "2": "172.26.117.167", "3": "172.26.117.179" },`