### PR TITLE
Some edit to the portgroup samples

### DIFF
--- a/samples/add_portgroup_to_vswitch.py
+++ b/samples/add_portgroup_to_vswitch.py
@@ -107,8 +107,10 @@ def AddHostPortgroup(host, vswitchName, portgroupName, vlanId):
     network_policy.security.forgedTransmits = False
     portgroup_spec.policy = network_policy
 
-    host.configManager.networkSystem.AddPortGroup(portgroup_spec)
-
+    try:
+        host.configManager.networkSystem.AddPortGroup(portgroup_spec)
+    except vim.fault.AlreadyExists:
+        print ("Portgroup already exist on host "+str(host.name))
 
 def main():
     args = get_args()


### PR DESCRIPTION
The two portgroup samples (`add_portgroup_to_vswitch` and `del_portgroup_from_vswitch`) fail if the porgroup already exist (for the _add_ script) or it's not found (for the _del_ script). I catch the exception and just print a warning.

The `del_portgroup_from_vswitch` doesn't have a option to ignore SSL certificate verification, I added one (`-c`) in a similar way of `add_portgroup_to_vswitch`.