### PR TITLE
upload file will not overwrite args anymore

### DIFF
--- a/samples/upload_file_to_vm.py
+++ b/samples/upload_file_to_vm.py
@@ -84,21 +84,21 @@ def main():
         creds = vim.vm.guest.NamePasswordAuthentication(
             username=args.vm_user, password=args.vm_pwd)
         with open(args.upload_file, 'rb') as myfile:
-            args = myfile.read()
+            fileinmemory = myfile.read()
 
         try:
             file_attribute = vim.vm.guest.FileManager.FileAttributes()
             url = content.guestOperationsManager.fileManager. \
                 InitiateFileTransferToGuest(vm, creds, vm_path,
                                             file_attribute,
-                                            len(args), True)
+                                            len(fileinmemory), True)
             # When : host argument becomes https://*:443/guestFile?
             # Ref: https://github.com/vmware/pyvmomi/blob/master/docs/ \
             #            vim/vm/guest/FileManager.rst
             # Script fails in that case, saying URL has an invalid label.
             # By having hostname in place will take take care of this.
             url = re.sub(r"^https://\*:", "https://"+str(args.host)+":", url)
-            resp = requests.put(url, data=args, verify=False)
+            resp = requests.put(url, data=fileinmemory, verify=False)
             if not resp.status_code == 200:
                 print "Error while uploading file"
             else:


### PR DESCRIPTION
The 'args' got overwritten by the file which was to be uploaded, resulting in errors.

Example of errors:

> Traceback (most recent call last):
>   File "./upload_file_to_vm.py", line 116, in <module>
>     main()
>   File "./upload_file_to_vm.py", line 100, in main
>     url = re.sub(r"^https://\*:", "https://"+str(args.host)+":", url)
> AttributeError: 'str' object has no attribute 'host'
