### PR TITLE
docs: Fix a few typos

### DIFF
--- a/samples/deploy_ovf.py
+++ b/samples/deploy_ovf.py
@@ -33,7 +33,7 @@ def get_ovf_descriptor(ovf_path):
 
 def get_obj_in_list(obj_name, obj_list):
     """
-    Gets an object out of a list (obj_list) whos name matches obj_name.
+    Gets an object out of a list (obj_list) whose name matches obj_name.
     """
     for obj in obj_list:
         if obj.name == obj_name:

--- a/samples/getorphanedvms.py
+++ b/samples/getorphanedvms.py
@@ -200,7 +200,7 @@ def find_match(uuid):
 def main():
     """
     function runs all of the other functions. Some parts of this function
-    are taken from the getallvms.py script from the pyvmomi gihub repo
+    are taken from the getallvms.py script from the pyvmomi github repo
     """
     parser = cli.Parser()
     parser.add_optional_arguments(cli.Argument.VM_NAME, cli.Argument.UUID, cli.Argument.PORT_GROUP)


### PR DESCRIPTION
There are small typos in:
- samples/deploy_ovf.py
- samples/getorphanedvms.py

Fixes:
- Should read `whose` rather than `whos`.
- Should read `github` rather than `gihub`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md