### PR TITLE
Fix the VCR example

### DIFF
--- a/samples/hello_world_vcenter_with_yaml_recorder.py
+++ b/samples/hello_world_vcenter_with_yaml_recorder.py
@@ -19,9 +19,10 @@ Python program to authenticate and print
 a friendly encouragement to joining the community!
 """
 
-import vcr
+from vcr import config
+from vcr.stubs import VCRHTTPSConnection
 from tools import cli, service_instance
-from pyVmomi import vmodl
+from pyVmomi import vmodl, SoapAdapter
 
 
 def main():
@@ -33,23 +34,23 @@ def main():
     args = parser.get_args()
 
     try:
-        my_vcr = vcr.VCR()
+        my_vcr = config.VCR(custom_patches=((SoapAdapter, "_HTTPSConnection", VCRHTTPSConnection),))
         # use the vcr instance to setup an instance of service_instance
         with my_vcr.use_cassette('hello_world_vcenter.yaml', record_mode='all'):
             si = service_instance.connect(args)
 
-        print("\nHello World!\n")
-        print("If you got here, you authenticted into vCenter.")
-        print("The server is {0}!".format(args.host))
-        # NOTE (hartsock): only a successfully authenticated session has a
-        # session key aka session id.
-        session_id = si.content.sessionManager.currentSession.key
-        print("current session id: {0}".format(session_id))
-        print("Well done!")
-        print("\n")
-        print("Download, learn and contribute back:")
-        print("https://github.com/vmware/pyvmomi-community-samples")
-        print("\n\n")
+            print("\nHello World!\n")
+            print("If you got here, you authenticted into vCenter.")
+            print("The server is {0}!".format(args.host))
+            # NOTE (hartsock): only a successfully authenticated session has a
+            # session key aka session id.
+            session_id = si.content.sessionManager.currentSession.key
+            print("current session id: {0}".format(session_id))
+            print("Well done!")
+            print("\n")
+            print("Download, learn and contribute back:")
+            print("https://github.com/vmware/pyvmomi-community-samples")
+            print("\n\n")
 
     except vmodl.MethodFault as error:
         print("Caught vmodl fault : " + error.msg)


### PR DESCRIPTION
There seem to be couple of issues with the VCR sample that prevented
me from running it.

1. The indentaiton seems wrong that si instance is needed to retrieve
session info
2. There needs to be a custom setting to VCR as per
https://github.com/vmware/pyvmomi/issues/852
https://github.com/kevin1024/vcrpy/issues/528

Signed-off-by:  Kiril Karaatanassov <kkaraatanassov@vmware.com>