### PR TITLE
Add port argument to http_url in upload_file_to_datastore.py

### DIFF
--- a/samples/upload_file_to_datastore.py
+++ b/samples/upload_file_to_datastore.py
@@ -63,7 +63,7 @@ def main():
         resource = "/folder" + remote_file
         params = {"dsName": datastore.info.name,
                   "dcPath": datacenter.name}
-        http_url = "https://" + args.host + ":443" + resource
+        http_url = "https://" + args.host + ":" + str(args.port) + resource
 
         # Get the cookie built from the current session
         client_cookie = si._stub.cookie


### PR DESCRIPTION
When running the `upload_file_to_datastore.py` sample, it currently ignores port specifications:

```
[kemo@raza files]$ python3 upload_iso.py 
usage: upload_iso.py [-h] -s HOST [-o PORT] -u USER [-p PASSWORD] [-nossl]
                     --datastore-name DATASTORE_NAME
                     [--local-file-path LOCAL_FILE_PATH]
                     [--remote-file-path REMOTE_FILE_PATH]
upload_iso.py: error: the following arguments are required: -s/--host, -u/--user, --datastore-name
```

When executing an upload it will timeout and fail due to the hard-coded 443 port:

```
[kemo@raza files]$ python3 upload_iso.py -s vcenter.example.com -o 7443 -u administrator@vsphere.example.com -p myPass -nossl --datastore-name datastore1 --local-file-path ../.generated/rhel8.iso --remote-file-path /ISOs/rhel8.iso
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/urllib3/connection.py", line 160, in _new_conn
    (self._dns_host, self.port), self.timeout, **extra_kw
  File "/usr/lib/python3.6/site-packages/urllib3/util/connection.py", line 84, in create_connection
    raise err
  File "/usr/lib/python3.6/site-packages/urllib3/util/connection.py", line 74, in create_connection
    sock.connect(sa)
TimeoutError: [Errno 110] Connection timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/urllib3/connectionpool.py", line 677, in urlopen
    chunked=chunked,
  File "/usr/lib/python3.6/site-packages/urllib3/connectionpool.py", line 381, in _make_request
    self._validate_conn(conn)
  File "/usr/lib/python3.6/site-packages/urllib3/connectionpool.py", line 978, in _validate_conn
    conn.connect()
  File "/usr/lib/python3.6/site-packages/urllib3/connection.py", line 309, in connect
    conn = self._new_conn()
  File "/usr/lib/python3.6/site-packages/urllib3/connection.py", line 172, in _new_conn
    self, "Failed to establish a new connection: %s" % e
urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPSConnection object at 0x7f4257369b38>: Failed to establish a new connection: [Errno 110] Connection timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/kemo/.local/lib/python3.6/site-packages/requests/adapters.py", line 449, in send
    timeout=timeout
  File "/usr/lib/python3.6/site-packages/urllib3/connectionpool.py", line 727, in urlopen
    method, url, error=e, _pool=self, _stacktrace=sys.exc_info()[2]
  File "/usr/lib/python3.6/site-packages/urllib3/util/retry.py", line 439, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='vcenter.example.com', port=443): Max retries exceeded with url: /folder/ISOs/rhel8.iso?dsName=datastore1&dcPath=LabDC (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f4257369b38>: Failed to establish a new connection: [Errno 110] Connection timed out',))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "upload_iso.py", line 105, in <module>
    main()
  File "upload_iso.py", line 94, in main
    verify=verify_cert)
  File "/home/kemo/.local/lib/python3.6/site-packages/requests/api.py", line 134, in put
    return request('put', url, data=data, **kwargs)
  File "/home/kemo/.local/lib/python3.6/site-packages/requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "/home/kemo/.local/lib/python3.6/site-packages/requests/sessions.py", line 530, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/kemo/.local/lib/python3.6/site-packages/requests/sessions.py", line 643, in send
    r = adapter.send(request, **kwargs)
  File "/home/kemo/.local/lib/python3.6/site-packages/requests/adapters.py", line 516, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='vcenter.example.com', port=443): Max retries exceeded with url: /folder/ISOs/rhel8.iso?dsName=datastore1&dcPath=LabDC (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f4257369b38>: Failed to establish a new connection: [Errno 110] Connection timed out',)
```

***The modification allows the port arguement to be reflected in the executed upload.***