### PR TITLE
args.vm_pwd argument causing the issue #resolved

### DIFF
--- a/samples/execute_program_in_vm.py
+++ b/samples/execute_program_in_vm.py
@@ -45,6 +45,7 @@ def main():
                                help='Program command line options. '
                                     'e.g. "/etc/network/interfaces > /tmp/plop"')
     args = parser.get_args()
+   
     si = service_instance.connect(args)
     try:
         content = si.RetrieveContent()
@@ -67,7 +68,7 @@ def main():
                 "is running")
 
         creds = vim.vm.guest.NamePasswordAuthentication(
-            username=args.vm_user, password=args.vm_pwd
+            username=args.vm_user, password=args.vm_password
         )
 
         try:


### PR DESCRIPTION
On execution of the script, It was showing that the args.vm_pwd does not exist. 

**Detail of the error:**
```
Traceback (most recent call last):
  File "execute_program_in_vm.py", line 113, in <module>
    main()
  File "execute_program_in_vm.py", line 64, in main
    username=args.vm_user, password=args.vm_pwd
AttributeError: 'Namespace' object has no attribute 'vm_pwd'
```
I resolved it by analyzing the arguments in the Namespace object


