### PR TITLE
Don't leave orphaned file after removing a disk

### DIFF
--- a/samples/delete_disk_from_vm.py
+++ b/samples/delete_disk_from_vm.py
@@ -54,6 +54,9 @@ def delete_virtual_disk(si, vm_obj, disk_number, language):
     virtual_hdd_spec = vim.vm.device.VirtualDeviceSpec()
     virtual_hdd_spec.operation = \
         vim.vm.device.VirtualDeviceSpec.Operation.remove
+    # remove the file that was used by disk as well
+    virtual_hdd_spec.fileOperation = \
+        vim.vm.device.VirtualDeviceSpec.FileOperation.destroy
     virtual_hdd_spec.device = virtual_hdd_device
 
     spec = vim.vm.ConfigSpec()
@@ -79,7 +82,7 @@ def main():
 
     if vm_obj:
         if not args.yes:
-            cli.prompt_y_n_question(f'Are you sure you want to delete "Hard Disk {args.unitnumber}"?',
+            cli.prompt_y_n_question(f'Are you sure you want to delete "Hard Disk {args.unitnumber}" and its file?',
                                     default='no')
         delete_virtual_disk(si, vm_obj, args.unitnumber, args.language)
         print('VM HDD "{}" successfully deleted.'.format(args.unitnumber))

--- a/samples/delete_disk_from_vm.py
+++ b/samples/delete_disk_from_vm.py
@@ -79,9 +79,7 @@ def main():
 
     if vm_obj:
         if not args.yes:
-            cli.prompt_y_n_question("Are you sure you want "
-                                    "to delete HDD "
-                                    "{}?".format(args.unitnumber),
+            cli.prompt_y_n_question(f'Are you sure you want to delete "Hard Disk {args.unitnumber}"?',
                                     default='no')
         delete_virtual_disk(si, vm_obj, args.unitnumber, args.language)
         print('VM HDD "{}" successfully deleted.'.format(args.unitnumber))


### PR DESCRIPTION
By default upon removing a disk ESXi just leaves out the file that was used for the disk. At my work we just had a problem of having HUNDREDs of these files all over the place. Fix this problem, by adding the option for removing the file.

Fixes: https://github.com/vmware/pyvmomi-community-samples/issues/608